### PR TITLE
Make boards more compact, and add cpu speed menu

### DIFF
--- a/attiny/boards.txt
+++ b/attiny/boards.txt
@@ -1,119 +1,77 @@
-attiny45.name=ATtiny45 (internal 1 MHz clock)
-attiny45.bootloader.low_fuses=0x62
+menu.speed=CPU Speed
+
+###########################################################
+
+attiny45.name=ATtiny45
 attiny45.bootloader.high_fuses=0xdf
 attiny45.bootloader.extended_fuses=0xff
 attiny45.upload.maximum_size=4096
 attiny45.build.mcu=attiny45
-attiny45.build.f_cpu=1000000L
 attiny45.build.core=arduino:arduino
 attiny45.build.variant=tiny8
+attiny45.menu.speed.1.name=1 MHz (internal)
+attiny45.menu.speed.1.bootloader.low_fuses=0x62
+attiny45.menu.speed.1.build.f_cpu=1000000L
+attiny45.menu.speed.8.name=8 MHz (internal)
+attiny45.menu.speed.8.bootloader.low_fuses=0xe2
+attiny45.menu.speed.8.build.f_cpu=8000000L
+attiny45.menu.speed.20.name=20 MHz (external)
+attiny45.menu.speed.20.bootloader.low_fuses=0xfe
+attiny45.menu.speed.20.build.f_cpu=20000000L
 
-attiny45-8.name=ATtiny45 (internal 8 MHz clock)
-attiny45-8.bootloader.low_fuses=0xe2
-attiny45-8.bootloader.high_fuses=0xdf
-attiny45-8.bootloader.extended_fuses=0xff
-attiny45-8.upload.maximum_size=4096
-attiny45-8.build.mcu=attiny45
-attiny45-8.build.f_cpu=8000000L
-attiny45-8.build.core=arduino:arduino
-attiny45-8.build.variant=tiny8
+###########################################################
 
-attiny45-20.name=ATtiny45 (external 20 MHz clock)
-attiny45-20.bootloader.low_fuses=0xfe
-attiny45-20.bootloader.high_fuses=0xdf
-attiny45-20.bootloader.extended_fuses=0xff
-attiny45-20.upload.maximum_size=4096
-attiny45-20.build.mcu=attiny45
-attiny45-20.build.f_cpu=20000000L
-attiny45-20.build.core=arduino:arduino
-attiny45-20.build.variant=tiny8
-
-attiny85.name=ATtiny85 (internal 1 MHz clock)
-attiny85.bootloader.low_fuses=0x62
+attiny85.name=ATtiny85
 attiny85.bootloader.high_fuses=0xdf
 attiny85.bootloader.extended_fuses=0xff
 attiny85.upload.maximum_size=8192
 attiny85.build.mcu=attiny85
-attiny85.build.f_cpu=1000000L
 attiny85.build.core=arduino:arduino
 attiny85.build.variant=tiny8
+attiny85.menu.speed.1.name=1 MHz (internal)
+attiny85.menu.speed.1.bootloader.low_fuses=0x62
+attiny85.menu.speed.1.build.f_cpu=1000000L
+attiny85.menu.speed.8.name=8 MHz (internal)
+attiny85.menu.speed.8.bootloader.low_fuses=0xe2
+attiny85.menu.speed.8.build.f_cpu=8000000L
+attiny85.menu.speed.20.name=20 MHz (external)
+attiny85.menu.speed.20.bootloader.low_fuses=0xfe
+attiny85.menu.speed.20.build.f_cpu=20000000L
 
-attiny85-8.name=ATtiny85 (internal 8 MHz clock)
-attiny85-8.bootloader.low_fuses=0xe2
-attiny85-8.bootloader.high_fuses=0xdf
-attiny85-8.bootloader.extended_fuses=0xff
-attiny85-8.upload.maximum_size=8192
-attiny85-8.build.mcu=attiny85
-attiny85-8.build.f_cpu=8000000L
-attiny85-8.build.core=arduino:arduino
-attiny85-8.build.variant=tiny8
+###########################################################
 
-attiny85-20.name=ATtiny85 (external 20 MHz clock)
-attiny85-20.bootloader.low_fuses=0xfe
-attiny85-20.bootloader.high_fuses=0xdf
-attiny85-20.bootloader.extended_fuses=0xff
-attiny85-20.upload.maximum_size=8192
-attiny85-20.build.mcu=attiny85
-attiny85-20.build.f_cpu=20000000L
-attiny85-20.build.core=arduino:arduino
-attiny85-20.build.variant=tiny8
-
-attiny44.name=ATtiny44 (internal 1 MHz clock)
-attiny44.bootloader.low_fuses=0x62
+attiny44.name=ATtiny44
 attiny44.bootloader.high_fuses=0xdf
 attiny44.bootloader.extended_fuses=0xff
 attiny44.upload.maximum_size=4096
 attiny44.build.mcu=attiny44
-attiny44.build.f_cpu=1000000L
 attiny44.build.core=arduino:arduino
 attiny44.build.variant=tiny14
+attiny44.menu.speed.1.name=1 MHz (internal)
+attiny44.menu.speed.1.bootloader.low_fuses=0x62
+attiny44.menu.speed.1.build.f_cpu=1000000L
+attiny44.menu.speed.8.name=8 MHz (internal)
+attiny44.menu.speed.8.bootloader.low_fuses=0xe2
+attiny44.menu.speed.8.build.f_cpu=8000000L
+attiny44.menu.speed.20.name=20 MHz (external)
+attiny44.menu.speed.20.bootloader.low_fuses=0xfe
+attiny44.menu.speed.20.build.f_cpu=20000000L
 
-attiny44-8.name=ATtiny44 (internal 8 MHz clock)
-attiny44-8.bootloader.low_fuses=0xe2
-attiny44-8.bootloader.high_fuses=0xdf
-attiny44-8.bootloader.extended_fuses=0xff
-attiny44-8.upload.maximum_size=4096
-attiny44-8.build.mcu=attiny44
-attiny44-8.build.f_cpu=8000000L
-attiny44-8.build.core=arduino:arduino
-attiny44-8.build.variant=tiny14
+###########################################################
 
-attiny44-20.name=ATtiny44 (external 20 MHz clock)
-attiny44-20.bootloader.low_fuses=0xfe
-attiny44-20.bootloader.high_fuses=0xdf
-attiny44-20.bootloader.extended_fuses=0xff
-attiny44-20.upload.maximum_size=4096
-attiny44-20.build.mcu=attiny44
-attiny44-20.build.f_cpu=20000000L
-attiny44-20.build.core=arduino:arduino
-attiny44-20.build.variant=tiny14
-
-attiny84.name=ATtiny84 (internal 1 MHz clock)
-attiny84.bootloader.low_fuses=0x62
+attiny84.name=ATtiny84
 attiny84.bootloader.high_fuses=0xdf
 attiny84.bootloader.extended_fuses=0xff
 attiny84.upload.maximum_size=8192
 attiny84.build.mcu=attiny84
-attiny84.build.f_cpu=1000000L
 attiny84.build.core=arduino:arduino
 attiny84.build.variant=tiny14
-
-attiny84-8.name=ATtiny84 (internal 8 MHz clock)
-attiny84-8.bootloader.low_fuses=0xe2
-attiny84-8.bootloader.high_fuses=0xdf
-attiny84-8.bootloader.extended_fuses=0xff
-attiny84-8.upload.maximum_size=8192
-attiny84-8.build.mcu=attiny84
-attiny84-8.build.f_cpu=8000000L
-attiny84-8.build.core=arduino:arduino
-attiny84-8.build.variant=tiny14
-
-attiny84-20.name=ATtiny84 (external 20 MHz clock)
-attiny84-20.bootloader.low_fuses=0xfe
-attiny84-20.bootloader.high_fuses=0xdf
-attiny84-20.bootloader.extended_fuses=0xff
-attiny84-20.upload.maximum_size=8192
-attiny84-20.build.mcu=attiny84
-attiny84-20.build.f_cpu=20000000L
-attiny84-20.build.core=arduino:arduino
-attiny84-20.build.variant=tiny14
+attiny84.menu.speed.1.name=1 MHz (internal)
+attiny84.menu.speed.1.bootloader.low_fuses=0x62
+attiny84.menu.speed.1.build.f_cpu=1000000L
+attiny84.menu.speed.8.name=8 MHz (internal)
+attiny84.menu.speed.8.bootloader.low_fuses=0xe2
+attiny84.menu.speed.8.build.f_cpu=8000000L
+attiny84.menu.speed.20.name=20 MHz (external)
+attiny84.menu.speed.20.bootloader.low_fuses=0xfe
+attiny84.menu.speed.20.build.f_cpu=20000000L


### PR DESCRIPTION
Add cpu speed menu containing boards' speeds, and group each micro-controller into a single board. Making the boards list more compact. This will avoid having the same board with different speed in the boards list, which makes finding a board in the list much easier.