### PR TITLE
Add analogReference Functionality

### DIFF
--- a/attiny45_85/cores/attiny45_85/arduino.h
+++ b/attiny45_85/cores/attiny45_85/arduino.h
@@ -1,0 +1,12 @@
+#ifndef ARDUINO_H
+#define ARDUINO_H
+
+#include "WProgram.h"
+#include "binary.h"
+#include "pins_arduino.h"
+#include "Print.h"
+#include "WConstants.h"
+#include "wiring.h"
+
+
+#endif

--- a/attiny45_85/cores/attiny45_85/pins_arduino.c
+++ b/attiny45_85/cores/attiny45_85/pins_arduino.c
@@ -86,7 +86,7 @@ const uint8_t PROGMEM digital_pin_to_bit_mask_PGM[] = {
 
 const uint8_t PROGMEM digital_pin_to_timer_PGM[] = {
 	TIMER0A, /* OC0A */
-	TIMER1,
+	TIMER1,	 /* 0C1A */ 
 	NOT_ON_TIMER,
 	NOT_ON_TIMER,
 	NOT_ON_TIMER,

--- a/attiny45_85/cores/attiny45_85/wiring.h
+++ b/attiny45_85/cores/attiny45_85/wiring.h
@@ -68,8 +68,10 @@ extern "C"{
 // end interrupts
 	
 #define INTERNAL 3
-#define DEFAULT 1
-#define EXTERNAL 0
+#define INTERNAL1V1 3
+#define INTERNAL2V56 2
+#define DEFAULT 1	
+#define EXTERNAL 0 
 
 // undefine stdlib's abs if encountered
 #ifdef abs


### PR DESCRIPTION
Full functionality for analogReference:
- DEFAULT: Use VCC as ref
- INTERNAL/INTERNAL1V1: Use internal 1v1 as ref
- INTERNAL2V56: Use internal 2v56 as ref
- EXTERNAL: Use external ref (not tested!)
