### PR TITLE
Silence warning when opening the boards manager.

### DIFF
--- a/attiny/avr/platform.txt
+++ b/attiny/avr/platform.txt
@@ -1,5 +1,6 @@
 name=ATtiny Microcontrollers
 
+tools.avrdude.path={runtime.tools.avrdude.path}
 tools.avrdude.erase.params.verbose=-v -v -v -v
 tools.avrdude.erase.params.quiet=-q -q
 tools.avrdude.erase.pattern="{cmd.path}" "-C{config.path}" {erase.verbose} -p{build.mcu} -c{protocol} {program.extra_params} -e -Uefuse:w:{bootloader.extended_fuses}:m -Uhfuse:w:{bootloader.high_fuses}:m -Ulfuse:w:{bootloader.low_fuses}:m


### PR DESCRIPTION
This change suppresses this warning in the IDE console when opening (and closing) the boards manager dialog:

    Warning: platform.txt from core 'ATtiny Microcontrollers' misses property
    tools.avrdude.path, automatically set to {runtime.tools.avrdude.path}.