### PR TITLE
Update platforms index to the most recent commit

### DIFF
--- a/package_damellis_attiny_index.json
+++ b/package_damellis_attiny_index.json
@@ -17,10 +17,10 @@
           "help": {
             "online": ""
           },
-          "url": "https://github.com/damellis/attiny/archive/702aa287455f7e052cf94fd4949398fec0ef21b8.zip",
-          "archiveFileName": "702aa287455f7e052cf94fd4949398fec0ef21b8.zip",
-          "checksum": "SHA-256:ec3ff8a1dc96d3ba6f432b9b837a35fd4174a34b3d2927de1d51010e8b94f9f1",
-          "size": "5005",
+          "url": "https://github.com/damellis/attiny/archive/76ca88ce3c195fcba8e8a645084e352965dc80e0.zip",
+          "archiveFileName": "76ca88ce3c195fcba8e8a645084e352965dc80e0.zip",
+          "checksum": "SHA-256:1d4cc6a915f8261c715c5911f2f55b502e54c24385670349404def3ffa77bf36",
+          "size": "5719",
           "boards": [
             {"name": "ATtiny45"},
             {"name": "ATtiny85"},


### PR DESCRIPTION
Update the install file URL in package_damellis_attiny_index.json to
include 76ca88c "Silence warning" commit.

Boards manager install URL for testing: https://raw.githubusercontent.com/per1234/attiny/json-update/package_damellis_attiny_index.json