### PR TITLE
Add SRAM size

### DIFF
--- a/attiny/avr/boards.txt
+++ b/attiny/avr/boards.txt
@@ -11,21 +11,25 @@ attiny.upload.tool=arduino:avrdude
 
 attiny.menu.cpu.attiny45=ATtiny45
 attiny.menu.cpu.attiny45.upload.maximum_size=4096
+attiny.menu.cpu.attiny45.upload.maximum_data_size=256
 attiny.menu.cpu.attiny45.build.mcu=attiny45
 attiny.menu.cpu.attiny45.build.variant=tiny8
 
 attiny.menu.cpu.attiny85=ATtiny85
 attiny.menu.cpu.attiny85.upload.maximum_size=8192
+attiny.menu.cpu.attiny85.upload.maximum_data_size=256
 attiny.menu.cpu.attiny85.build.mcu=attiny85
 attiny.menu.cpu.attiny85.build.variant=tiny8
 
 attiny.menu.cpu.attiny44=ATtiny44
 attiny.menu.cpu.attiny44.upload.maximum_size=4096
+attiny.menu.cpu.attiny44.upload.maximum_data_size=256
 attiny.menu.cpu.attiny44.build.mcu=attiny44
 attiny.menu.cpu.attiny44.build.variant=tiny14
 
 attiny.menu.cpu.attiny84=ATtiny84
 attiny.menu.cpu.attiny84.upload.maximum_size=8192
+attiny.menu.cpu.attiny84.upload.maximum_data_size=512
 attiny.menu.cpu.attiny84.build.mcu=attiny84
 attiny.menu.cpu.attiny84.build.variant=tiny14
 


### PR DESCRIPTION
I sometimes encountered programs not running on ATtiny85. I added the sizes according datasheets to have the IDE check the RAM size before uploading buggy code.

Maybe the same changes have to be applied to other trees for different IDE versions?