### PR TITLE
Added programmers for Sloeber

### DIFF
--- a/externalprogrammers.txt
+++ b/externalprogrammers.txt
@@ -1,0 +1,24 @@
+
+################################
+## These programmers will only
+## appear if you're using the
+## ArduinoEclipse/Sloeber IDE.
+## Download this great software
+## at: http://eclipse.baeyens.it
+################################
+
+#As far as jantje knows only the ArduinoISP makes sence for the attiny
+
+arduinoisp.name=ArduinoISP
+arduinoisp.protocol=arduinoisp
+arduinoisp.program.tool=avrdude
+arduinoisp.program.extra_params=
+
+arduinoasisp.name=Arduino as ISP
+arduinoasisp.communication=serial
+arduinoasisp.protocol=stk500v1
+arduinoasisp.speed=19200
+arduinoasisp.program.protocol=stk500v1
+arduinoasisp.program.speed=19200
+arduinoasisp.program.tool=avrdude
+arduinoasisp.program.extra_params=-P{serial.port} -b{program.speed}


### PR DESCRIPTION
Hi
Jantje here from Sloeber the Arduino eclipse ide here.
I'd like you to merge this pull request to fix a problem with your attiny repository and Sloeber.

The Arduino ide adds all programmers for all boards to the programmers list
Sloeber only shows programmers for the currently active board. Therefore there are no programmers for the attiny in Sloeber. 
This issue first was visible with mighty core and we decided to go with a new file that will be ignored by the arduino ide and that allows sloeber to have per board programmers.
https://github.com/MCUdude/MightyCore/commit/bde915548060317fc8bd6793dcbbe63feae17310#diff-5ab0db77a30b9c1514ec01118ccafc44

Compliant with that implementation I would like you to add this file to your repository.
As for the content for the attiny I think (I don't own one) only the arduino as isp makes sense so this programmers list only contains the arduino as isp.
Please be so kind to accept this pull request
Best regards
Jantje